### PR TITLE
[#21] :sparkles: feat: 여행 코스 리포지토리 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,12 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    //QueryDsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/team/seventhmile/tripforp/domain/plan/entity/Area.java
+++ b/src/main/java/team/seventhmile/tripforp/domain/plan/entity/Area.java
@@ -1,5 +1,7 @@
 package team.seventhmile.tripforp.domain.plan.entity;
 
+import java.util.HashMap;
+import java.util.Map;
 import lombok.Getter;
 
 @Getter
@@ -24,9 +26,20 @@ public enum Area {
 
     private final String name;
 
+    private static final Map<String, Area> NAME_TO_ENUM_MAP = new HashMap<>();
+
     Area(String name) {
         this.name = name;
     }
 
+    static {
+        for (Area area : Area.values()) {
+            NAME_TO_ENUM_MAP.put(area.getName(), area);
+        }
+    }
 
+    // 한글 이름을 통해 Enum을 반환하는 메서드
+    public static Area fromName(String name) {
+        return NAME_TO_ENUM_MAP.get(name);
+    }
 }

--- a/src/main/java/team/seventhmile/tripforp/domain/plan/repository/PlanRepository.java
+++ b/src/main/java/team/seventhmile/tripforp/domain/plan/repository/PlanRepository.java
@@ -1,0 +1,8 @@
+package team.seventhmile.tripforp.domain.plan.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.seventhmile.tripforp.domain.plan.entity.Plan;
+
+public interface PlanRepository extends JpaRepository<Plan, Long>, PlanRepositoryCustom {
+
+}

--- a/src/main/java/team/seventhmile/tripforp/domain/plan/repository/PlanRepositoryCustom.java
+++ b/src/main/java/team/seventhmile/tripforp/domain/plan/repository/PlanRepositoryCustom.java
@@ -1,0 +1,12 @@
+package team.seventhmile.tripforp.domain.plan.repository;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import team.seventhmile.tripforp.domain.plan.entity.Plan;
+
+public interface PlanRepositoryCustom {
+
+    Page<Plan> getPlans(String area, Pageable pageable);
+
+}

--- a/src/main/java/team/seventhmile/tripforp/domain/plan/repository/PlanRepositoryImpl.java
+++ b/src/main/java/team/seventhmile/tripforp/domain/plan/repository/PlanRepositoryImpl.java
@@ -1,0 +1,42 @@
+package team.seventhmile.tripforp.domain.plan.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import team.seventhmile.tripforp.domain.plan.entity.Area;
+import team.seventhmile.tripforp.domain.plan.entity.Plan;
+import team.seventhmile.tripforp.domain.plan.entity.QPlan;
+
+@RequiredArgsConstructor
+@Repository
+public class PlanRepositoryImpl implements PlanRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    private final QPlan qPlan = QPlan.plan;
+
+    @Override
+    public Page<Plan> getPlans(String area, Pageable pageable) {
+        List<Plan> plans = queryFactory.selectFrom(qPlan)
+            .where(equalArea(area))
+            .limit(pageable.getPageSize())
+            .offset(pageable.getOffset())
+            .fetch();
+
+        JPAQuery<Long> count = queryFactory
+            .select(qPlan.count())
+            .from(qPlan)
+            .where(equalArea(area));
+
+        return PageableExecutionUtils.getPage(plans, pageable, count::fetchOne);
+    }
+
+    private BooleanExpression equalArea(String area) {
+        return area != null ? qPlan.area.eq(Area.fromName(area)) : null;
+    }
+}

--- a/src/main/java/team/seventhmile/tripforp/global/config/QuerydslConfig.java
+++ b/src/main/java/team/seventhmile/tripforp/global/config/QuerydslConfig.java
@@ -1,0 +1,17 @@
+package team.seventhmile.tripforp.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QuerydslConfig {
+    private final EntityManager em;
+    @Bean
+    public JPAQueryFactory queryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/test/java/team/seventhmile/tripforp/domain/plan/repository/PlanRepositoryTest.java
+++ b/src/test/java/team/seventhmile/tripforp/domain/plan/repository/PlanRepositoryTest.java
@@ -1,0 +1,108 @@
+package team.seventhmile.tripforp.domain.plan.repository;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.List;
+import org.aspectj.lang.annotation.Before;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import team.seventhmile.tripforp.domain.plan.entity.Area;
+import team.seventhmile.tripforp.domain.plan.entity.Plan;
+import team.seventhmile.tripforp.domain.plan.entity.QPlan;
+import team.seventhmile.tripforp.global.config.QuerydslConfig;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@TestPropertySource(locations = "classpath:application.yml")
+@Import(QuerydslConfig.class)
+public class PlanRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private JPAQueryFactory queryFactory;
+
+    @Autowired
+    private PlanRepository planRepository;
+
+    private final QPlan qPlan = QPlan.plan;
+
+    @BeforeEach
+    public void setup() {
+        Plan plan1 = Plan.builder()
+            .startDate(LocalDate.now())
+            .endDate(LocalDate.now().plusDays(2))
+            .area(Area.BUSAN)
+            .title("부산 여행")
+            .build();
+        planRepository.save(plan1);
+
+        Plan plan2 = Plan.builder()
+            .startDate(LocalDate.now())
+            .endDate(LocalDate.now().plusDays(2))
+            .area(Area.SEOUL)
+            .title("서울 여행")
+            .build();
+        planRepository.save(plan2);
+    }
+
+    @Test
+    @DisplayName("여행 코스 목록 조회 - 지역 = 서울특별시")
+    void testGetPlans1() {
+        //given
+        String area = "서울특별시";
+
+        BooleanExpression condition = area != null ? qPlan.area.eq(Area.fromName(area)) : null;
+        //when
+        List<Plan> result = queryFactory.selectFrom(qPlan)
+            .where(condition)
+            .fetch();
+        //then
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.get(0).getTitle()).isEqualTo("서울 여행");
+     }
+
+    @Test
+    @DisplayName("여행 코스 목록 조회 - 지역 = null")
+    void testGetPlans2() {
+        //given
+        String area = null;
+
+        BooleanExpression condition = area != null ? qPlan.area.eq(Area.fromName(area)) : null;
+        //when
+        List<Plan> result = queryFactory.selectFrom(qPlan)
+            .where(condition)
+            .fetch();
+        //then
+        assertThat(result.size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("여행 코스 목록 조회 - 지역 = 경기도")
+    void testGetPlans3() {
+        //given
+        String area = "경기도";
+
+        BooleanExpression condition = area != null ? qPlan.area.eq(Area.fromName(area)) : null;
+        //when
+        List<Plan> result = queryFactory.selectFrom(qPlan)
+            .where(condition)
+            .fetch();
+        //then
+        assertThat(result.size()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
## 요약
> 테스트 코드 및 리포지토리 구현

## 관련 이슈
- close #21 

## 변경 사항
- QueryDSL 설정
- Area 한글 지명으로 Enum 반환 메서드 추가
- 여행 코스 목록 조회 테스트 코드 작성
- 여행 코스 목록 조회 메서드 구현

## 기타
- 추후에 좋아요 기준 Top 5 목록 조회 구현해야합니다!
