### PR TITLE
[#139] ✨docs: 매거진 권한 확인 코드 추가

### DIFF
--- a/src/main/java/team/seventhmile/tripforp/domain/free_post/service/FreePostService.java
+++ b/src/main/java/team/seventhmile/tripforp/domain/free_post/service/FreePostService.java
@@ -15,83 +15,91 @@ import team.seventhmile.tripforp.domain.free_post.repository.FreePostRepository;
 @Service
 public class FreePostService {
 
-    private final FreePostRepository freePostRepository;
+	private final FreePostRepository freePostRepository;
 
-    @Autowired
-    public FreePostService(FreePostRepository freePostRepository) {
-        this.freePostRepository = freePostRepository;
-    }
+	@Autowired
+	public FreePostService(FreePostRepository freePostRepository) {
+		this.freePostRepository = freePostRepository;
+	}
 
-    // 자유 게시글 생성
-    @Transactional
-    public FreePostDto createFreePost(FreePostDto freePostDto) {
+	// 자유 게시글 생성
+	@Transactional
+	public FreePostDto createFreePost(FreePostDto freePostDto) {
 
-        FreePost freePost = freePostDto.toEntity();
-        freePostRepository.save(freePost);
+		FreePost freePost = freePostDto.toEntity();
+		freePostRepository.save(freePost);
 
-        return FreePostDto.fromEntity(freePost);
+		return FreePostDto.fromEntity(freePost);
 
-    }
+	}
 
-    // 자유 게시글 수정
-    @Transactional
-    public FreePostDto updateFreePost(Long id, FreePostDto freePostDto) {
+	// 자유 게시글 수정
+	@Transactional
+	public FreePostDto updateFreePost(Long id, FreePostDto freePostDto) {
 
-        FreePost freePost = freePostRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException("데이터를 찾을 수 없습니다."));
+		FreePost freePost = freePostRepository.findById(id)
+			.orElseThrow(() -> new EntityNotFoundException("데이터를 찾을 수 없습니다."));
 
-        freePost.update(
-                freePostDto.getContent(),
-                freePostDto.getViews()
-        );
+		freePost.update(
+			freePostDto.getContent(),
+			freePostDto.getViews()
+		);
 
-        freePostRepository.save(freePost);
+		freePostRepository.save(freePost);
 
-        return FreePostDto.fromEntity(freePost);
+		return FreePostDto.fromEntity(freePost);
 
-    }
+	}
 
-    // 자유 게시글 삭제
-    @Transactional
-    public void deleteFreePost(Long id) {
+	// 자유 게시글 삭제
+	@Transactional
+	public void deleteFreePost(Long id) {
 
-        FreePost freePost = freePostRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException("데이터를 찾을 수 없습니다."));
-        freePostRepository.delete(freePost);
+		FreePost freePost = freePostRepository.findById(id)
+			.orElseThrow(() -> new EntityNotFoundException("데이터를 찾을 수 없습니다."));
+		freePostRepository.delete(freePost);
 
-    }
+	}
 
-    // 자유 게시글 목록 조회
-    @Transactional(readOnly = true)
-    public Page<FreePostDto> getAllFreePost(Pageable pageable) {
+	// 자유 게시글 목록 조회
+	@Transactional(readOnly = true)
+	public Page<FreePostDto> getAllFreePost(Pageable pageable) {
 
-        return freePostRepository.getFreePosts(pageable)
-                .map(FreePostDto::fromEntity);
+		return freePostRepository.getFreePosts(pageable)
+			.map(FreePostDto::fromEntity);
 
-    }
+	}
 
-    // 자유 게시글 상세 조회
-    @Transactional(readOnly = true)
-    public FreePostDto getFreePostDetail(Long id) {
+	// 자유 게시글 상세 조회
+	@Transactional(readOnly = true)
+	public FreePostDto getFreePostDetail(Long id) {
 
-        return freePostRepository.findById(id)
-                .map(FreePostDto::fromEntity)
-                .orElseThrow(() -> new EntityNotFoundException("데이터를 찾을 수 없습니다."));
+		return freePostRepository.findById(id)
+			.map(FreePostDto::fromEntity)
+			.orElseThrow(() -> new EntityNotFoundException("데이터를 찾을 수 없습니다."));
 
-    }
+	}
 
-    // 자유 게시글 검색(제목, 내용) 조회
-    @Transactional(readOnly = true)
-    public Page<FreePostDto> getFreePostSearch(String keyword, Pageable pageable) {
+	// 자유 게시글 검색(제목, 내용) 조회
+	@Transactional(readOnly = true)
+	public Page<FreePostDto> getFreePostSearch(String keyword, Pageable pageable) {
 
-        if (keyword == null || keyword.trim().isEmpty()) {
-            return Page.empty(pageable);
-        }
+		if (keyword == null || keyword.trim().isEmpty()) {
+			return Page.empty(pageable);
+		}
 
-        Page<FreePost> freePosts = freePostRepository.getFreePostKeywordContaining(keyword.trim(), pageable);
-        return freePosts.map(FreePostDto::fromEntity);
+		Page<FreePost> freePosts = freePostRepository.getFreePostKeywordContaining(keyword.trim(),
+			pageable);
+		return freePosts.map(FreePostDto::fromEntity);
 
-    }
+	}
+
+	// FreePost 엔티티 조회
+	@Transactional(readOnly = true)
+	public FreePost getFreePostEntity(Long id) {
+		return freePostRepository.findById(id)
+			.orElseThrow(() -> new EntityNotFoundException("데이터를 찾을 수 없습니다."));
+	}
 
 
 }

--- a/src/main/java/team/seventhmile/tripforp/domain/magazine/controller/MagazineController.java
+++ b/src/main/java/team/seventhmile/tripforp/domain/magazine/controller/MagazineController.java
@@ -6,6 +6,9 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -13,9 +16,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import team.seventhmile.tripforp.domain.magazine.dto.MagazineDto;
 import team.seventhmile.tripforp.domain.magazine.service.MagazineService;
+import team.seventhmile.tripforp.domain.user.entity.User;
 
 @RestController
 @RequestMapping("/api/magazines")
@@ -28,7 +33,10 @@ public class MagazineController {
 		this.magazineService = magazineService;
 	}
 
-	// 매거진 글 목록 조회
+	/**
+	 * 모든 매거진 글 목록을 조회합니다.
+	 * @return 매거진 글 목록
+	 */
 	@GetMapping
 	public ResponseEntity<List<MagazineDto>> getAllMagazineList() {
 		List<MagazineDto> magazine = magazineService.getAllMagazineList()
@@ -36,7 +44,11 @@ public class MagazineController {
 		return ResponseEntity.ok(magazine);
 	}
 
-	// 매거진 글 상세 보기
+	/**
+	 * 특정 ID의 매거진 글을 조회합니다.
+	 * @param id 조회할 매거진 글의 ID
+	 * @return 매거진 글 상세 정보
+	 */
 	@GetMapping("/{id}")
 	public ResponseEntity<MagazineDto> getMagazineDetail(@PathVariable("id") Long id) {
 		return magazineService.getMagazineDetail(id)
@@ -44,27 +56,53 @@ public class MagazineController {
 			.orElse(ResponseEntity.notFound().build());
 	}
 
-	// 매거진 글 작성 하기
+	/**
+	 * 새로운 매거진 글을 작성합니다.
+	 * @param magazineDto 작성할 매거진 글 정보
+	 * @param userDetails 현재 인증된 사용자 정보
+	 * @return 생성된 매거진 글 정보
+	 */
 	@PostMapping
+	@PreAuthorize("hasRole('ADMIN')")
 	public ResponseEntity<MagazineDto> createMagazinePost(
-		@Valid @RequestBody MagazineDto magazineDto) {
-		magazineService.createMagazinePost(magazineDto);
+		@Valid @RequestBody MagazineDto magazineDto,
+		@AuthenticationPrincipal UserDetails userDetails) {
+		User user = (User) userDetails;
+		magazineService.createMagazinePost(magazineDto, user.getId());
 		return ResponseEntity.status(HttpStatus.CREATED).body(magazineDto);
 	}
 
-	// 매거진 글 수정 하기
+	/**
+	 * 특정 ID의 매거진 글을 수정합니다.
+	 * @param id 수정할 매거진 글의 ID
+	 * @param magazineDto 수정할 매거진 글 정보
+	 * @param userDetails 현재 인증된 사용자 정보
+	 * @return 수정된 매거진 글 정보
+	 */
 	@PutMapping("/{id}")
+	@PreAuthorize("hasRole('ADMIN')")
 	public ResponseEntity<MagazineDto> updateMagazinePost(
 		@PathVariable("id") Long id,
-		@Valid @RequestBody MagazineDto magazineDto) {
-		magazineService.updateMagazinePost(id, magazineDto);
+		@Valid @RequestBody MagazineDto magazineDto,
+		@AuthenticationPrincipal UserDetails userDetails) {
+		User user = (User) userDetails;
+		magazineService.updateMagazinePost(id, magazineDto, user.getId());
 		return ResponseEntity.ok(magazineDto);
 	}
 
-	// 매거진 글 삭제 하기
+	/**
+	 * 특정 ID의 매거진 글을 삭제합니다.
+	 * @param id 삭제할 매거진 글의 ID
+	 * @param userDetails 현재 인증된 사용자 정보
+	 * @return 삭제 성공 여부
+	 */
 	@DeleteMapping("/{id}")
-	public ResponseEntity<Void> deleteMagazinePost(@PathVariable("id") Long id) {
-		magazineService.deleteMagazinePost(id);
+	@PreAuthorize("hasRole('ADMIN')")
+	public ResponseEntity<Void> deleteMagazinePost(
+		@PathVariable("id") Long id,
+		@AuthenticationPrincipal UserDetails userDetails) {
+		User user = (User) userDetails;
+		magazineService.deleteMagazinePost(id, user.getId());
 		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/team/seventhmile/tripforp/domain/magazine/dto/MagazineDto.java
+++ b/src/main/java/team/seventhmile/tripforp/domain/magazine/dto/MagazineDto.java
@@ -1,7 +1,7 @@
 package team.seventhmile.tripforp.domain.magazine.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -9,6 +9,7 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import team.seventhmile.tripforp.domain.magazine.entity.Magazine;
+import team.seventhmile.tripforp.domain.user.entity.User;
 
 @Builder
 @AllArgsConstructor
@@ -19,9 +20,11 @@ public class MagazineDto {
 
 	private Long id;
 
+	@NotBlank
 	@Size(max = 255, message = "제목은 255자를 초과할 수 없습니다.")
 	private String title;
 
+	@NotBlank
 	@Size(max = 999999, message = "내용은 999999자를 초과할 수 없습니다.")
 	private String content;
 
@@ -29,7 +32,7 @@ public class MagazineDto {
 	private ZonedDateTime updatedAt;
 
 	// dto -> entity 변환
-	public static Magazine convertToEntity(MagazineDto magazineDto) {
+	public static Magazine convertToEntity(MagazineDto magazineDto, User user) {
 		return Magazine.builder()
 			.title(magazineDto.getTitle())
 			.content(magazineDto.getContent())

--- a/src/main/java/team/seventhmile/tripforp/domain/magazine/entity/Magazine.java
+++ b/src/main/java/team/seventhmile/tripforp/domain/magazine/entity/Magazine.java
@@ -2,18 +2,19 @@ package team.seventhmile.tripforp.domain.magazine.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import team.seventhmile.tripforp.domain.magazine.dto.MagazineDto;
+import team.seventhmile.tripforp.domain.user.entity.User;
 import team.seventhmile.tripforp.global.common.BaseEntity;
 
 @Entity
@@ -27,10 +28,13 @@ public class Magazine extends BaseEntity {
 	// 게시글 id
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column (name = "magazine_post_id")
+	@Column(name = "magazine_post_id")
 	private Long id;
 
 	// 회원 id
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
 
 	// 제목
 	@Column(nullable = false)

--- a/src/main/java/team/seventhmile/tripforp/domain/magazine/repository/MagazineRepository.java
+++ b/src/main/java/team/seventhmile/tripforp/domain/magazine/repository/MagazineRepository.java
@@ -8,7 +8,5 @@ import team.seventhmile.tripforp.domain.magazine.entity.Magazine;
 public interface MagazineRepository extends JpaRepository<Magazine, Long> {
 
     List<Magazine> findAllByOrderByIdDesc();
-
-    Optional<Magazine> findById(Long id);
 }
 


### PR DESCRIPTION
## 요약
> 매거진 권한 확인 코드 추가

## 관련 이슈
- close #139 

## 변경 사항
[컨트롤러]
- 매거진 글 작성, 수정, 삭제 코드에 @PreAuthorize("hasRole('ADMIN')") 사용
- @AuthenticationPrincipal 사용

[서비스]
- 매거진 글 작성, 수정, 삭제 코드에 if (user.getRole() != Role.ADMIN) 사용

[Dto]
- BaseEntity가 LocalDateTime 에서 ZonedDateTime으로 바뀜에 따라 변형

[레포지토리]
- 불필요한 findById 메소드 삭제

## 기타
> 기타 사항
