### PR TITLE
[#154] ✨ feat: JWT Refresh 토큰 발급

### DIFF
--- a/src/main/java/team/seventhmile/tripforp/domain/user/controller/UserController.java
+++ b/src/main/java/team/seventhmile/tripforp/domain/user/controller/UserController.java
@@ -1,7 +1,7 @@
 package team.seventhmile.tripforp.domain.user.controller;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -43,20 +43,9 @@ public class UserController {
 
 	// refresh 토큰 재발급
 	@PostMapping("/reissue")
-	public ResponseEntity<?> reissue(HttpServletRequest request) {
-		String refreshToken = extractRefreshTokenFromCookie(request);
-		return jwtUtil.reissueAccessToken(refreshToken);
+	public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) {
+
+		return jwtUtil.reissueToken(request, response);
 	}
 
-	private String extractRefreshTokenFromCookie(HttpServletRequest request) {
-		Cookie[] cookies = request.getCookies();
-		if (cookies != null) {
-			for (Cookie cookie : cookies) {
-				if (cookie.getName().equals("refresh")) {
-					return cookie.getValue();
-				}
-			}
-		}
-		return null;
-	}
 }

--- a/src/main/java/team/seventhmile/tripforp/domain/user/controller/UserController.java
+++ b/src/main/java/team/seventhmile/tripforp/domain/user/controller/UserController.java
@@ -1,5 +1,7 @@
 package team.seventhmile.tripforp.domain.user.controller;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import team.seventhmile.tripforp.domain.user.dto.UserDto;
 import team.seventhmile.tripforp.domain.user.service.UserService;
+import team.seventhmile.tripforp.global.jwt.JwtUtil;
 
 @Controller
 @RequiredArgsConstructor
@@ -18,6 +21,7 @@ import team.seventhmile.tripforp.domain.user.service.UserService;
 public class UserController {
 
 	private final UserService userService;
+	private final JwtUtil jwtUtil;
 
 	// 회원가입
 	@PostMapping("/registration")
@@ -37,4 +41,22 @@ public class UserController {
 			? ResponseEntity.status(HttpStatus.CONFLICT).body(true) : ResponseEntity.ok(false);
 	}
 
+	// refresh 토큰 재발급
+	@PostMapping("/reissue")
+	public ResponseEntity<?> reissue(HttpServletRequest request) {
+		String refreshToken = extractRefreshTokenFromCookie(request);
+		return jwtUtil.reissueAccessToken(refreshToken);
+	}
+
+	private String extractRefreshTokenFromCookie(HttpServletRequest request) {
+		Cookie[] cookies = request.getCookies();
+		if (cookies != null) {
+			for (Cookie cookie : cookies) {
+				if (cookie.getName().equals("refresh")) {
+					return cookie.getValue();
+				}
+			}
+		}
+		return null;
+	}
 }

--- a/src/main/java/team/seventhmile/tripforp/global/config/SecurityConfig.java
+++ b/src/main/java/team/seventhmile/tripforp/global/config/SecurityConfig.java
@@ -56,6 +56,7 @@ public class SecurityConfig {
 		http
 			.authorizeHttpRequests((auth) -> auth
 				.requestMatchers("/", "/api/**").permitAll()
+				.requestMatchers("/api/users/reissue").permitAll()
 				.anyRequest().permitAll());
 
 		//JWTFilter 등록

--- a/src/main/java/team/seventhmile/tripforp/global/jwt/JwtFilter.java
+++ b/src/main/java/team/seventhmile/tripforp/global/jwt/JwtFilter.java
@@ -1,10 +1,12 @@
 package team.seventhmile.tripforp.global.jwt;
 
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.io.PrintWriter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -23,63 +25,57 @@ public class JwtFilter extends OncePerRequestFilter {
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 		FilterChain filterChain) throws ServletException, IOException {
 
-		//request에서 Authorization 헤더를 찾음
-		String authorization = request.getHeader("Authorization");
+		// 헤더에서 access키에 담긴 토큰을 꺼냄
+		String accessToken = request.getHeader("access");
 
-		//Authorization 헤더 검증
-		if (authorization == null || !authorization.startsWith("Bearer ")) {
+		// 토큰이 없다면 다음 필터로 넘김
+		if (accessToken == null) {
 
-			System.out.println("token null");
 			filterChain.doFilter(request, response);
 
-			//조건이 해당되면 메소드 종료 (필수)
 			return;
 		}
 
-		System.out.println("authorization now");
-		//Bearer 부분 제거 후 순수 토큰만 획득
-		String token = authorization.split(" ")[1];
+		// 토큰 만료 여부 확인, 만료시 다음 필터로 넘기지 않음
+		try {
+			jwtUtil.isExpired(accessToken);
+		} catch (ExpiredJwtException e) {
 
-		//토큰 소멸 시간 검증
-		if (jwtUtil.isExpired(token)) {
+			//response body
+			PrintWriter writer = response.getWriter();
+			writer.print("access token expired");
 
-			System.out.println("token expired");
-			filterChain.doFilter(request, response);
-
-			//조건이 해당되면 메소드 종료 (필수)
+			//response status code
+			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 			return;
 		}
 
-		//토큰에서 username과 role 획득
-		String username = jwtUtil.getUsername(token);
-		String role = jwtUtil.getRole(token);
+		// 토큰이 access인지 확인 (발급시 페이로드에 명시)
+		String category = jwtUtil.getCategory(accessToken);
 
-		//userEntity를 생성하여 값 set
-//		User user = new User();
-//		user.setEmail(username);
-//		user.setPassword("temppassword");
-//		user.setRole(Role.valueOf(role));
+		if (!category.equals("access")) {
+
+			//response body
+			PrintWriter writer = response.getWriter();
+			writer.print("invalid access token");
+
+			//response status code
+			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+			return;
+		}
+		// === 토큰 검증 완료 ===
+		// username, role 값을 획득
+		String username = jwtUtil.getUsername(accessToken);
+		String role = jwtUtil.getRole(accessToken);
 
 		User user = User.builder()
 			.email(username)
-			.password("temppassword")
 			.role(Role.valueOf(role))
 			.build();
-		logger.debug("JWT filter username: " + username);
-		logger.debug("JWT filter role: " + role);
-		logger.debug("JWT filter expired: " + jwtUtil.isExpired(token));
-		logger.debug("JWT filter authorization: " + request.getHeader("Authorization"));
-
-		//UserDetails에 회원 정보 객체 담기
 		CustomUserDetails customUserDetails = new CustomUserDetails(user);
-		logger.debug("JWT filter authorities: " + customUserDetails.getAuthorities());
 
-//		List<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority("ROLE_ADMIN"));
-
-		//스프링 시큐리티 인증 토큰 생성
 		Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null,
 			customUserDetails.getAuthorities());
-		//세션에 사용자 등록
 		SecurityContextHolder.getContext().setAuthentication(authToken);
 
 		filterChain.doFilter(request, response);

--- a/src/main/java/team/seventhmile/tripforp/global/jwt/JwtUtil.java
+++ b/src/main/java/team/seventhmile/tripforp/global/jwt/JwtUtil.java
@@ -31,15 +31,22 @@ public class JwtUtil {
 			.get("role", String.class);
 	}
 
+	public String getCategory(String token) {
+
+		return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
+			.get("category", String.class);
+	}
+
 	public Boolean isExpired(String token) {
 
 		return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
 			.getExpiration().before(new Date());
 	}
 
-	public String createJwt(String username, String role, Long expiredMs) {
+	public String createJwt(String category, String username, String role, Long expiredMs) {
 
 		return Jwts.builder()
+			.claim("category", category)
 			.claim("username", username)
 			.claim("role", role)
 			.issuedAt(new Date(System.currentTimeMillis()))

--- a/src/main/java/team/seventhmile/tripforp/global/jwt/LoginFilter.java
+++ b/src/main/java/team/seventhmile/tripforp/global/jwt/LoginFilter.java
@@ -1,18 +1,19 @@
 package team.seventhmile.tripforp.global.jwt;
 
 import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Collection;
 import java.util.Iterator;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import team.seventhmile.tripforp.domain.user.service.CustomUserDetails;
 
 @RequiredArgsConstructor
 public class LoginFilter extends UsernamePasswordAuthenticationFilter {
@@ -43,9 +44,12 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 	@Override
 	protected void successfulAuthentication(HttpServletRequest request,
 		HttpServletResponse response, FilterChain chain, Authentication authentication) {
-		CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
 
-		String username = customUserDetails.getUsername();
+		// CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+		// String username = customUserDetails.getUsername();
+
+		//유저 정보
+		String username = authentication.getName();
 
 		Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
 		Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
@@ -54,9 +58,14 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 		// ROLE_USER 중 뒷 부분 USER만 가져옴
 		String role = auth.getAuthority().split("_")[1];
 
-		String token = jwtUtil.createJwt(username, role, 60 * 60 * 100L);
+		//토큰 생성
+		String access = jwtUtil.createJwt("access", username, role, 600000L);
+		String refresh = jwtUtil.createJwt("refresh", username, role, 86400000L);
 
-		response.addHeader("Authorization", "Bearer " + token);
+		//응답 설정
+		response.setHeader("access", access);
+		response.addCookie(createCookie("refresh", refresh));
+		response.setStatus(HttpStatus.OK.value());
 
 	}
 
@@ -66,5 +75,16 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 		HttpServletResponse response, AuthenticationException failed) {
 		//로그인 실패시 401 응답 코드 반환
 		response.setStatus(401);
+	}
+
+	private Cookie createCookie(String key, String value) {
+
+		Cookie cookie = new Cookie(key, value);
+		cookie.setMaxAge(24 * 60 * 60);
+		//cookie.setSecure(true);
+		//cookie.setPath("/");
+		cookie.setHttpOnly(true);
+
+		return cookie;
 	}
 }


### PR DESCRIPTION
## 요약
> JWT Refresh 토큰 발급
## 관련 이슈
- close #154 

## 변경 사항
> - JWT refresh 토큰 발급
> - 발급받은 refresh 토큰을 통해 access 토큰을 재발급 받을 수 있습니다.
> `/api/users/reissue`
> - access 토큰이 재발행이 될 때마다 refresh 토큰도 재발행

## 기타
> - 에러처리는 추후 리팩토링 하도록 하겠습니다.
> - postman에서 테스트 시
>  기존 Headers - `Authoriztion`을 추가해 access 토큰을 넣어주었다면,
>  현재는 `access`를 추가해 발급받은 access 토큰을 넣어주셔야 합니다.
