### PR TITLE
[#160] ✨ feat: JWT Refresh 토큰 redis 저장 구현

### DIFF
--- a/src/main/java/team/seventhmile/tripforp/domain/user/service/TokenService.java
+++ b/src/main/java/team/seventhmile/tripforp/domain/user/service/TokenService.java
@@ -1,0 +1,31 @@
+package team.seventhmile.tripforp.domain.user.service;
+
+import java.util.concurrent.TimeUnit;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TokenService {
+
+	private final RedisTemplate<String, String> redisTemplate;
+
+	@Autowired
+	public TokenService(RedisTemplate<String, String> redisTemplate) {
+		this.redisTemplate = redisTemplate;
+	}
+
+	public void saveRefreshToken(String username, String refreshToken) {
+		// Refresh token을 Redis에 저장 (만료 시간: 24시간)
+		redisTemplate.opsForValue().set(username, refreshToken, 1, TimeUnit.DAYS);
+	}
+
+	public String getRefreshToken(String username) {
+		return redisTemplate.opsForValue().get(username);
+	}
+
+	public void deleteRefreshToken(String username) {
+		redisTemplate.delete(username);
+	}
+}
+

--- a/src/main/java/team/seventhmile/tripforp/global/config/SecurityConfig.java
+++ b/src/main/java/team/seventhmile/tripforp/global/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import team.seventhmile.tripforp.domain.user.service.TokenService;
 import team.seventhmile.tripforp.global.jwt.JwtFilter;
 import team.seventhmile.tripforp.global.jwt.JwtUtil;
 import team.seventhmile.tripforp.global.jwt.LoginFilter;
@@ -24,6 +25,8 @@ public class SecurityConfig {
 	private final AuthenticationConfiguration authenticationConfiguration;
 
 	private final JwtUtil jwtUtil;
+
+	private final TokenService tokenService;
 
 	//AuthenticationManager Bean 등록
 	@Bean
@@ -41,7 +44,7 @@ public class SecurityConfig {
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
 		LoginFilter loginFilter = new LoginFilter(
-			authenticationManager(authenticationConfiguration), jwtUtil);
+			authenticationManager(authenticationConfiguration), jwtUtil, tokenService);
 		loginFilter.setFilterProcessesUrl("/api/users/signin");
 
 		http
@@ -55,8 +58,9 @@ public class SecurityConfig {
 
 		http
 			.authorizeHttpRequests((auth) -> auth
-				.requestMatchers("/", "/api/**").permitAll()
+				.requestMatchers("/", "/api/users/**").permitAll()
 				.requestMatchers("/api/users/reissue").permitAll()
+				.requestMatchers("/api/plans/**").hasRole("USER")
 				.anyRequest().permitAll());
 
 		//JWTFilter 등록

--- a/src/main/java/team/seventhmile/tripforp/global/config/SecurityConfig.java
+++ b/src/main/java/team/seventhmile/tripforp/global/config/SecurityConfig.java
@@ -58,9 +58,8 @@ public class SecurityConfig {
 
 		http
 			.authorizeHttpRequests((auth) -> auth
-				.requestMatchers("/", "/api/users/**").permitAll()
+				.requestMatchers("/", "/api/**").permitAll()
 				.requestMatchers("/api/users/reissue").permitAll()
-				.requestMatchers("/api/plans/**").hasRole("USER")
 				.anyRequest().permitAll());
 
 		//JWTFilter 등록


### PR DESCRIPTION
## 요약
> JWT Refresh 토큰 redis 저장 구현

## 관련 이슈
- close #160 

## 변경 사항
> -  TokenService
> redis에 refresh토큰을 저장 하고 가져오는 로직 구현
> - LoginFilter
> - JwtUtil

## 기타
> 로그인 시 발급되는 refresh 토큰을 저장합니다 (username(=email), refreshToken)
> reissue 시 발급되는 refresh 토큰을 저장합니다 (username(=email), newRefreshToken)
