### PR TITLE
[#179] 🐛 Fix : RedisConfig의 RedisTemplate 통일화

### DIFF
--- a/src/main/java/team/seventhmile/tripforp/domain/user/service/EmailService.java
+++ b/src/main/java/team/seventhmile/tripforp/domain/user/service/EmailService.java
@@ -2,7 +2,7 @@ package team.seventhmile.tripforp.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class EmailService {
     private final JavaMailSender javaMailSender;
-    private final StringRedisTemplate redisTemplate;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     //이메일 인증 코드 전송
     public void sendVerificationEmail(String recipient) {
@@ -46,7 +46,8 @@ public class EmailService {
     }
     //이메일 인증코드 검증
     public boolean verifyEmailCode(String email, String code) {
-        String storedCode = redisTemplate.opsForValue().get("EMAIL_CODE:" + email);
+        Object storedCodeObj = redisTemplate.opsForValue().get("EMAIL_CODE:" + email);
+        String storedCode = storedCodeObj != null ? storedCodeObj.toString() : null;
         log.info("server 이메일과 인증코드 {}: {}", email, storedCode);
         log.info("client 인증코드 : {}", code);
         if (storedCode != null && storedCode.equals(code)) {

--- a/src/main/java/team/seventhmile/tripforp/domain/user/service/TokenService.java
+++ b/src/main/java/team/seventhmile/tripforp/domain/user/service/TokenService.java
@@ -8,20 +8,20 @@ import org.springframework.stereotype.Service;
 @Service
 public class TokenService {
 
-	private final RedisTemplate<String, String> redisTemplate;
+	private final RedisTemplate<String, Object> redisTemplate;
 
 	@Autowired
-	public TokenService(RedisTemplate<String, String> redisTemplate) {
+	public TokenService(RedisTemplate<String, Object> redisTemplate) {
 		this.redisTemplate = redisTemplate;
 	}
 
 	public void saveRefreshToken(String username, String refreshToken) {
-		// Refresh token을 Redis에 저장 (만료 시간: 24시간)
 		redisTemplate.opsForValue().set(username, refreshToken, 1, TimeUnit.DAYS);
 	}
 
 	public String getRefreshToken(String username) {
-		return redisTemplate.opsForValue().get(username);
+		Object token = redisTemplate.opsForValue().get(username);
+		return (token != null) ? token.toString() : null;
 	}
 
 	public void deleteRefreshToken(String username) {

--- a/src/main/java/team/seventhmile/tripforp/global/config/RedisConfig.java
+++ b/src/main/java/team/seventhmile/tripforp/global/config/RedisConfig.java
@@ -7,6 +7,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -26,11 +27,11 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, String> redisTemplate(){
-        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+    public RedisTemplate<String, Object> redisTemplate(){
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
         return redisTemplate;
     }
 }


### PR DESCRIPTION
## 요약
> TokenService와 EmailService 이 두 서비스가 동일한 Redis 인스턴스를 사용하면서 서로 다른 타입의 템플릿을 사용하고 있음.
문제가 될 수 있으므로, 일관성을 위해 두 서비스 모두 RedisTemplate<String, Objects>로 변경.

## 관련 이슈
- close #179 

## 변경 사항
> `RedisConfig`
> - `RedisTemplate<String, String>` 에서 `<String, Object>`로 변경
> - 직렬화 방식 `GenericJackson2JsonRedisSerializer` 사용
> - 그에 따라 `TokenService`와 `EmailService` 도 함께 변경

## 기타
> 기타 사항
