### PR TITLE
[#184] ✨ Feat : 로그아웃 구현

### DIFF
--- a/src/main/java/team/seventhmile/tripforp/domain/user/entity/User.java
+++ b/src/main/java/team/seventhmile/tripforp/domain/user/entity/User.java
@@ -26,13 +26,13 @@ public class User extends BaseEntity {
 	@Column(name = "user_id")
 	private Long id;
 
-	@Column(nullable = false)
+	@Column(nullable = false, unique = true)
 	private String email;
 
 	@Column(nullable = false)
 	private String password;
 
-	@Column(nullable = false)
+	@Column(nullable = false, unique = true)
 	private String nickname;
 
 	@Column(nullable = false)

--- a/src/main/java/team/seventhmile/tripforp/domain/user/service/TokenService.java
+++ b/src/main/java/team/seventhmile/tripforp/domain/user/service/TokenService.java
@@ -27,5 +27,10 @@ public class TokenService {
 	public void deleteRefreshToken(String username) {
 		redisTemplate.delete(username);
 	}
+
+	public boolean isKeyExists(String username) {
+		Boolean hasKey = redisTemplate.hasKey(username);
+		return hasKey != null && hasKey;
+	}
 }
 

--- a/src/main/java/team/seventhmile/tripforp/global/jwt/CustomLogoutFilter.java
+++ b/src/main/java/team/seventhmile/tripforp/global/jwt/CustomLogoutFilter.java
@@ -1,0 +1,106 @@
+package team.seventhmile.tripforp.global.jwt;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.filter.GenericFilterBean;
+import team.seventhmile.tripforp.domain.user.service.TokenService;
+
+@RequiredArgsConstructor
+public class CustomLogoutFilter extends GenericFilterBean {
+
+	private final JwtUtil jwtUtil;
+	private final TokenService tokenService;
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+		throws IOException, ServletException {
+
+		doFilter((HttpServletRequest) request, (HttpServletResponse) response, chain);
+	}
+
+	private void doFilter(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws IOException, ServletException {
+
+		//path and method 확인
+		String requestUri = request.getRequestURI();
+		if (!requestUri.matches("^\\/api\\/users\\/signout$")) {
+
+			filterChain.doFilter(request, response);
+			return;
+		}
+		String requestMethod = request.getMethod();
+		if (!requestMethod.equals("POST")) {
+
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		//get refresh token
+		String refresh = null;
+		Cookie[] cookies = request.getCookies();
+		if (cookies != null) {
+			for (Cookie cookie : cookies) {
+				if (cookie.getName().equals("refresh")) {
+					refresh = cookie.getValue();
+					break;
+				}
+			}
+		}
+
+		//refresh null 값인지 check
+		if (refresh == null) {
+
+			response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+			return;
+		}
+
+		//refresh 만료 여부 check
+		try {
+			jwtUtil.isExpired(refresh);
+		} catch (ExpiredJwtException e) {
+
+			//response status code
+			response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+			return;
+		}
+
+		// 토큰이 refresh 인지 확인 (발급시 페이로드에 명시)
+		String category = jwtUtil.getCategory(refresh);
+		if (!category.equals("refresh")) {
+
+			//response status code
+			response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+			return;
+		}
+
+		//refresh 토큰이 저장되어 있는지 확인
+		String username = jwtUtil.getUsername(refresh);
+		Boolean isKeyExist = tokenService.isKeyExists(username);
+		if (!isKeyExist) {
+
+			//response status code
+			response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+			return;
+		}
+
+		//로그아웃 진행
+		//redis 에서 refresh 토큰 제거
+		tokenService.deleteRefreshToken(username);
+
+		//Refresh 토큰 Cookie 값 0
+		Cookie cookie = new Cookie("refresh", null);
+		cookie.setMaxAge(0);
+		cookie.setPath("/api/users");
+
+		response.addCookie(cookie);
+		response.setStatus(HttpServletResponse.SC_OK);
+	}
+}


### PR DESCRIPTION
## 요약
> - user 엔티티에 email, nickname unique 키 값 추가
> - 로그아웃 구현

## 관련 이슈
- close #184 

## 변경 사항
> `CustomLogoutFilter`
> - redis에 저장되어 있는 Refresh 토큰 삭제
> - 쿠키에 담겨있는 Refresh 토큰 삭제

## 기타
> 로그아웃 경로는 `/api/users/signout`입니다.
> 에러 핸들링은 성윤님이 작업중이신 ErrorCode파일에 추가하기 위해 추후 추가하도록 하겠습니다.
