### PR TITLE
[#221] ✨Feat: 개인정보수정 BE(마이페이지) 구현

### DIFF
--- a/src/main/java/team/seventhmile/tripforp/domain/user/controller/MyPageController.java
+++ b/src/main/java/team/seventhmile/tripforp/domain/user/controller/MyPageController.java
@@ -5,12 +5,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import team.seventhmile.tripforp.domain.user.dto.UserInfoRequest;
 import team.seventhmile.tripforp.domain.user.dto.UserInfoResponse;
 import team.seventhmile.tripforp.domain.user.service.MyPageService;
-import team.seventhmile.tripforp.domain.user.service.UserService;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -18,11 +16,19 @@ import team.seventhmile.tripforp.domain.user.service.UserService;
 @RequestMapping("/api/mypage")
 public class MyPageController {
     private final MyPageService myPageService;
-    private final UserService userService;
 
     //(마이페이지)개인정보 조회
     @GetMapping("/info")
     public ResponseEntity<UserInfoResponse> getUserInfo(@AuthenticationPrincipal UserDetails userDetails){
         return ResponseEntity.ok(myPageService.getUserInfo(userDetails));
+    }
+
+    //개인정보 수정
+    @PatchMapping("/info")
+    public ResponseEntity<UserInfoResponse> updateUser(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody UserInfoRequest userInfoReq){
+
+        return ResponseEntity.ok(myPageService.updateInfo(userDetails, userInfoReq));
     }
 }

--- a/src/main/java/team/seventhmile/tripforp/domain/user/dto/UserInfoRequest.java
+++ b/src/main/java/team/seventhmile/tripforp/domain/user/dto/UserInfoRequest.java
@@ -1,0 +1,14 @@
+package team.seventhmile.tripforp.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter @Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserInfoRequest {
+    private String password;
+    private String nickname;
+}

--- a/src/main/java/team/seventhmile/tripforp/domain/user/entity/User.java
+++ b/src/main/java/team/seventhmile/tripforp/domain/user/entity/User.java
@@ -57,4 +57,12 @@ public class User extends BaseEntity {
 	public UserGetDto toDto() {
 		return new UserGetDto(this.nickname, this.email);
 	}
+
+	//[마이페이지] - 개인정보수정
+	public void updateNickname(String nickname){
+		this.nickname = nickname;
+	}
+	public void updatePassword(String password){
+		this.password = password;
+	}
 }

--- a/src/main/java/team/seventhmile/tripforp/domain/user/service/EmailService.java
+++ b/src/main/java/team/seventhmile/tripforp/domain/user/service/EmailService.java
@@ -35,11 +35,11 @@ public class EmailService {
             //중복
             throw new AuthCustomException(ErrorCode.EMAIL_ALREADY_IN_USE);
         }
-        String emailCode = generateEmailCode();
+        String emailCode = generateEmailCode().trim();
         SimpleMailMessage message = new SimpleMailMessage();
         message.setTo(recipient); //수신자 설정
         message.setSubject("이메일 인증"); //제목 설정
-        message.setText("귀하의 인증 코드는 " + emailCode + " 입니다.\n인증 코드는 5분 간 유지됩니다."); //내용 설정
+        message.setText("귀하의 인증 코드는 " + emailCode + "입니다.\n인증 코드는 5분 간 유지됩니다."); //내용 설정
         try {
             javaMailSender.send(message);
             redisTemplate.opsForValue().set("EMAIL_CODE:" + recipient, emailCode, 5, TimeUnit.MINUTES);

--- a/src/main/java/team/seventhmile/tripforp/domain/user/service/MyPageService.java
+++ b/src/main/java/team/seventhmile/tripforp/domain/user/service/MyPageService.java
@@ -3,8 +3,10 @@ package team.seventhmile.tripforp.domain.user.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team.seventhmile.tripforp.domain.user.dto.UserInfoRequest;
 import team.seventhmile.tripforp.domain.user.dto.UserInfoResponse;
 import team.seventhmile.tripforp.domain.user.entity.User;
 import team.seventhmile.tripforp.domain.user.repository.UserRepository;
@@ -16,6 +18,7 @@ import team.seventhmile.tripforp.global.exception.ErrorCode;
 @RequiredArgsConstructor
 public class MyPageService {
     private final UserRepository userRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     //개인정보 조회
     @Transactional(readOnly = true)
@@ -23,5 +26,25 @@ public class MyPageService {
         User user = userRepository.findByEmail(userDetails.getUsername())
                 .orElseThrow(()-> new AuthCustomException(ErrorCode.USER_NOT_FOUND));
         return UserInfoResponse.from(user);
+    }
+    //개인정보 수정
+    @Transactional
+    public UserInfoResponse updateInfo(UserDetails userDetails, UserInfoRequest userInfoReq){
+        User updatedUser = userRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(()-> new AuthCustomException(ErrorCode.USER_NOT_FOUND));
+        // 닉네임 업데이트 (수정 요청 있는 경우)
+        if (userInfoReq.getNickname() != null && !userInfoReq.getNickname().isEmpty()) {
+            if (userRepository.existsByNickname(userInfoReq.getNickname())) {
+                log.info("MyPage '{}' 사용 중인 Nickname", userInfoReq.getNickname());
+                throw new AuthCustomException(ErrorCode.NICKNAME_ALREADY_IN_USE);
+            }
+            updatedUser.updateNickname(userInfoReq.getNickname());
+        }
+        //비밀번호 변경(수정 요청 있는 경우)
+        if (userInfoReq.getPassword() != null && !userInfoReq.getPassword().isEmpty()) {
+            String newPassword = bCryptPasswordEncoder.encode(userInfoReq.getPassword());
+            updatedUser.updatePassword(newPassword);
+        }
+        return UserInfoResponse.from(updatedUser);
     }
 }


### PR DESCRIPTION
## 요약
> 마이페이지 개인정보 수정 BE(비밀번호, 닉네임) 구현

## 관련 이슈
- close #221 

## 변경 사항
> 마이페이지 개인정보 수정 BE 구현
> 이메일 인증코드 전송 시 공백 제거(trim)

## 기타

